### PR TITLE
Added the Exem Prep button in mobile nav

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -832,6 +832,16 @@ const generatePDF = () => {
               <span className="mobile-menu-icon">🎯</span>
               Practice
             </button>
+            <button 
+              className="mobile-menu-item" 
+              onClick={() => {
+                showExamPrep();
+                setIsMobileMenuOpen(false);
+              }}
+            >
+              <span className="mobile-menu-icon">📚</span>
+              Exam Prep
+            </button>
             {user ? (
               <>
                 <button 


### PR DESCRIPTION
Closes #85 

Added the button for Exam Prep page in Mobile Nav

<img width="403" height="329" alt="image" src="https://github.com/user-attachments/assets/3443daab-5ccb-4a2f-ae55-524623b0a40e" />
